### PR TITLE
Add dotenv support to examples

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_openai_api_key

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ git clone https://github.com/run-llama/openai_realtime_client.git
 cd openai_realtime_client
 ```
 
-Set your openai key:
+Set your OpenAI key by creating a `.env` file in the project root:
 
 ```bash
-export OPENAI_API_KEY="sk-..."
+echo "OPENAI_API_KEY=sk-..." > .env
 ```
 
 ## Usage

--- a/examples/manual_cli.py
+++ b/examples/manual_cli.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from dotenv import load_dotenv
 
 from pynput import keyboard
 from openai_realtime_client import RealtimeClient, InputHandler, AudioHandler
@@ -19,6 +20,7 @@ def get_phone_number(name: str) -> str:
 tools = [FunctionTool.from_defaults(fn=get_phone_number)]
 
 async def main():
+    load_dotenv()
     # Initialize handlers
     audio_handler = AudioHandler()
     input_handler = InputHandler()

--- a/examples/streaming_cli.py
+++ b/examples/streaming_cli.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from dotenv import load_dotenv
 
 from pynput import keyboard
 from openai_realtime_client import RealtimeClient, AudioHandler, InputHandler, TurnDetectionMode
@@ -19,6 +20,7 @@ def get_phone_number(name: str) -> str:
 tools = [FunctionTool.from_defaults(fn=get_phone_number)]
 
 async def main():
+    load_dotenv()
     audio_handler = AudioHandler()
     input_handler = InputHandler()
     input_handler.loop = asyncio.get_running_loop()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ pynput = "^1.7.7"
 pydub = "^0.25.1"
 websockets = "^13.1"
 wave = "^0.0.2"
+python-dotenv = "^1.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- add python-dotenv as dependency
- include `.env` file with `OPENAI_API_KEY` placeholder
- update example scripts to load environment variables with `python-dotenv`
- document `.env` usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875b25d6008323acfc8ad55d809244