### PR TITLE
Fix WebSocket protocol in web demo

### DIFF
--- a/examples/static/app.js
+++ b/examples/static/app.js
@@ -13,7 +13,8 @@ const hal = document.querySelector('.animation');
 hal.classList.add('idle');
 
 startBtn.addEventListener('click', async () => {
-    ws = new WebSocket(`ws://${location.host}/ws`);
+    const protocol = location.protocol === 'https:' ? 'wss' : 'ws';
+    ws = new WebSocket(`${protocol}://${location.host}/ws`);
     ws.onmessage = handleMessage;
     await startAudio();
     startBtn.disabled = true;

--- a/examples/ws_hal9000.py
+++ b/examples/ws_hal9000.py
@@ -2,7 +2,7 @@ import os
 import asyncio
 from dotenv import load_dotenv
 from pynput import keyboard
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, WebSocket
 from fastapi.responses import JSONResponse
 from starlette.staticfiles import StaticFiles
 from openai_realtime_client import RealtimeClient, TurnDetectionMode, WsHandler, InputHandler


### PR DESCRIPTION
## Summary
- allow the web demo to use secure WebSockets when served via HTTPS
- clean up an unused import detected by ruff

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889e5fb6b1083239b328b6af14ecbe3