### PR TITLE
Add async context manager support

### DIFF
--- a/examples/manual_cli.py
+++ b/examples/manual_cli.py
@@ -19,7 +19,7 @@ async def main():
     input_handler.loop = asyncio.get_running_loop()
     
     # Initialize the realtime client
-    client = RealtimeClient(
+    client_args = dict(
         api_key=os.environ.get("OPENAI_API_KEY"),
         model=os.environ.get("OPENAI_MODEL"),
         on_text_delta=lambda text: print(f"\nAssistant: {text}", end="", flush=True),
@@ -32,52 +32,49 @@ async def main():
     # Start keyboard listener in a separate thread
     listener = keyboard.Listener(on_press=input_handler.on_press)
     listener.start()
-    
-    try:
-        # Connect to the API
-        await client.connect()
-        
-        # Start message handling in the background
-        asyncio.create_task(client.handle_messages())
-        
-        print("Connected to OpenAI Realtime API!")
-        print("Commands:")
-        print("- Type your message and press Enter to send text")
-        print("- Press 'r' to start recording audio")
-        print("- Press 'space' to stop recording")
-        print("- Press 'q' to quit")
-        print("")        
- 
-        while True:
-            # Wait for commands from the input handler
-            command, data = await input_handler.command_queue.get()
-            
-            if command == 'q':
-                break
-            elif command == 'r':
-                # Start recording
-                audio_handler.start_recording()
-            elif command == 'space':
-                print("[About to stop recording]")
-                if audio_handler.recording:
-                    # Stop recording and get audio data
-                    audio_data = audio_handler.stop_recording()
-                    print("[Recording stopped]")
-                    if audio_data:
-                        await client.send_audio(audio_data)
-                        print("[Audio sent]")
-            elif command == 'enter' and data:
-                # Send text message
-                await client.send_text(data)
 
-            await asyncio.sleep(0.01) 
+    try:
+        async with RealtimeClient(**client_args) as client:
+            # Start message handling in the background
+            asyncio.create_task(client.handle_messages())
+
+            print("Connected to OpenAI Realtime API!")
+            print("Commands:")
+            print("- Type your message and press Enter to send text")
+            print("- Press 'r' to start recording audio")
+            print("- Press 'space' to stop recording")
+            print("- Press 'q' to quit")
+            print("")
+
+            while True:
+                # Wait for commands from the input handler
+                command, data = await input_handler.command_queue.get()
+
+                if command == 'q':
+                    break
+                elif command == 'r':
+                    # Start recording
+                    audio_handler.start_recording()
+                elif command == 'space':
+                    print("[About to stop recording]")
+                    if audio_handler.recording:
+                        # Stop recording and get audio data
+                        audio_data = audio_handler.stop_recording()
+                        print("[Recording stopped]")
+                        if audio_data:
+                            await client.send_audio(audio_data)
+                            print("[Audio sent]")
+                elif command == 'enter' and data:
+                    # Send text message
+                    await client.send_text(data)
+
+                await asyncio.sleep(0.01)
     except Exception as e:
         print(f"Error: {e}")
     finally:
         # Clean up
         listener.stop()
         audio_handler.cleanup()
-        await client.close()
 
 if __name__ == "__main__":
     # Install required packages:

--- a/examples/streaming_cli.py
+++ b/examples/streaming_cli.py
@@ -19,7 +19,7 @@ async def main():
     input_handler = InputHandler()
     input_handler.loop = asyncio.get_running_loop()
     
-    client = RealtimeClient(
+    client_args = dict(
         api_key=os.environ.get("OPENAI_API_KEY"),
         model=os.environ.get("OPENAI_MODEL"),
         on_text_delta=lambda text: print(f"\nAssistant: {text}", end="", flush=True),
@@ -35,32 +35,31 @@ async def main():
     # Start keyboard listener in a separate thread
     listener = keyboard.Listener(on_press=input_handler.on_press)
     listener.start()
-    
+
     try:
-        await client.connect()
-        asyncio.create_task(client.handle_messages())
-        
-        print("Connected to OpenAI Realtime API!")
-        print("Audio streaming will start automatically.")
-        print("Press 'q' to quit")
-        print("")
-        
-        # Start continuous audio streaming
-        asyncio.create_task(audio_handler.start_streaming(client))
-        
-        # Simple input loop for quit command
-        while True:
-            command, _ = await input_handler.command_queue.get()
-            
-            if command == 'q':
-                break
+        async with RealtimeClient(**client_args) as client:
+            asyncio.create_task(client.handle_messages())
+
+            print("Connected to OpenAI Realtime API!")
+            print("Audio streaming will start automatically.")
+            print("Press 'q' to quit")
+            print("")
+
+            # Start continuous audio streaming
+            asyncio.create_task(audio_handler.start_streaming(client))
+
+            # Simple input loop for quit command
+            while True:
+                command, _ = await input_handler.command_queue.get()
+
+                if command == 'q':
+                    break
             
     except Exception as e:
         print(f"Error: {e}")
     finally:
         audio_handler.stop_streaming()
         audio_handler.cleanup()
-        await client.close()
 
 if __name__ == "__main__":
     print("Starting Realtime API CLI with Server VAD...")

--- a/openai_realtime_client/client/realtime_client.py
+++ b/openai_realtime_client/client/realtime_client.py
@@ -111,10 +111,18 @@ class RealtimeClient:
         # Track printing state for input and output transcripts
         self._print_input_transcript = False
         self._output_transcript_buffer = ""
-        
-        
+    async def __aenter__(self) -> "RealtimeClient":
+        """Enter the runtime context and connect to the API."""
+        await self.connect()
+        return self
 
-        
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        """Exit the runtime context and close the connection."""
+        try:
+            await self.close()
+        finally:
+            if exc:
+                return False
 
     async def connect(self) -> None:
         """Establish WebSocket connection with the Realtime API."""


### PR DESCRIPTION
## Summary
- support `async with` by adding `__aenter__`/`__aexit__` to `RealtimeClient`
- update CLI examples to use the new context manager

## Testing
- `python -m py_compile openai_realtime_client/client/realtime_client.py examples/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6889eeb87c548323955b036e19e25b52