### PR TITLE
Implement rag tool wrappers

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,4 +1,3 @@
-from .tools import get_current_time, get_current_date
-from rag.rag_tool import query_rag
-
-__all__ = ["get_current_time", "get_current_date", "query_rag"]
+from .tools import get_current_time, get_current_date, query_rag
+from rag.rag_tool import aquery_rag
+__all__ = ["get_current_time", "get_current_date", "query_rag", "aquery_rag"]

--- a/examples/tools.py
+++ b/examples/tools.py
@@ -47,6 +47,28 @@ def get_current_date() -> dict:
     }
 
 
-def query_rag() -> str:
-    # TODO: call query_rag() in rag_tool
-    return "TEST"
+def query_rag(query: str, top_k: int = 10, top_n: int = 3) -> str:
+    """Return a response from the local RAG index.
+
+    Parameters
+    ----------
+    query : str
+        The query string to search for in the indexed documents.
+    top_k : int, optional
+        Number of documents to retrieve from the index before reranking.
+    top_n : int, optional
+        Number of documents to return after reranking.
+    """
+
+    from rag.rag_tool import query_rag as _query_rag
+
+    response = _query_rag(query=query, top_k=top_k, top_n=top_n)
+    return str(response)
+
+
+async def aquery_rag(query: str, top_k: int = 10, top_n: int = 3) -> str:
+    """Async wrapper around :func:`rag.rag_tool.aquery_rag`."""
+    from rag.rag_tool import aquery_rag as _aquery_rag
+
+    response = await _aquery_rag(query=query, top_k=top_k, top_n=top_n)
+    return str(response)

--- a/rag/rag_tool.py
+++ b/rag/rag_tool.py
@@ -52,3 +52,22 @@ def query_rag(query: str, top_k: int = 10, top_n: int = 3) -> Any:
     engine = index.as_query_engine(retriever=retriever, node_postprocessors=postprocessors)
     response = engine.query(query)
     return response
+
+
+async def aquery_rag(query: str, top_k: int = 10, top_n: int = 3) -> Any:
+    """Asynchronously query the RAG index and return the reranked response."""
+    index = get_index()
+    retriever = index.as_retriever(similarity_top_k=top_k)
+    reranker = LLMRerank(
+        llm=OpenAI(model=RAG_MODEL),
+        top_n=top_n,
+        choice_select_prompt=CHOICE_SELECT_PROMPT,
+    )
+    postprocessors = [SimilarityPostprocessor(similarity_cutoff=0.0), reranker]
+    engine = index.as_query_engine(
+        retriever=retriever,
+        node_postprocessors=postprocessors,
+    )
+    response = await engine.aquery(query)
+    return response
+


### PR DESCRIPTION
## Summary
- wire up the example `query_rag` function to the real RAG tool
- expose `aquery_rag` async helper
- export new functions in `examples.__init__`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip check`

------
https://chatgpt.com/codex/tasks/task_e_688a19488fb4832394982e7c24223d88