### PR TITLE
feat: add unity websocket connector

### DIFF
--- a/examples/unity/README.md
+++ b/examples/unity/README.md
@@ -1,0 +1,31 @@
+# Unity Realtime Connector
+
+This example shows how to connect a Unity NPC avatar with the Python OpenAI Realtime client.
+It streams microphone audio from Unity to the model and plays back the generated audio response.
+
+## Python WebSocket server
+
+1. Install dependencies and set your OpenAI key in a `.env` file (see project README).
+2. Start the server:
+
+```bash
+pip install fastapi uvicorn websockets python-dotenv
+python examples/unity_ws_server.py
+```
+
+The server exposes a WebSocket endpoint at `ws://localhost:8000/ws` that accepts raw PCM16 audio
+and returns base64 encoded audio chunks from the assistant.
+
+## Unity setup
+
+1. Import the [`UnityRealtimeConnector.cs`](UnityRealtimeConnector.cs) script into your project.
+2. Add the [`websocket-sharp`](https://github.com/sta/websocket-sharp) library to enable WebSocket support.
+3. Create a GameObject and attach `UnityRealtimeConnector`.
+4. Assign an `AudioSource` component on the same object to play the assistant's voice.
+5. Ensure that microphone permission is granted and run the scene. The NPC will speak using the
+assistant's response and the microphone input is streamed to the model.
+
+## Notes
+
+- Audio is sent and received as 16‑bit PCM. The server converts output to 24 kHz mono before playback.
+- Modify `serverUrl` in the script if the Python server runs on another host/port.

--- a/examples/unity/UnityRealtimeConnector.cs
+++ b/examples/unity/UnityRealtimeConnector.cs
@@ -1,0 +1,101 @@
+using UnityEngine;
+using WebSocketSharp;
+using System;
+
+public class UnityRealtimeConnector : MonoBehaviour
+{
+    [Header("WebSocket settings")]
+    public string serverUrl = "ws://localhost:8000/ws";
+    public AudioSource audioSource;
+
+    private WebSocket ws;
+    private AudioClip micClip;
+    private int lastSample = 0;
+
+    void Start()
+    {
+        // Connect to the Python WebSocket server
+        ws = new WebSocket(serverUrl);
+        ws.OnMessage += OnMessage;
+        ws.Connect();
+
+        // Begin recording from the default microphone
+        micClip = Microphone.Start(null, true, 1, 16000);
+
+        // Send audio chunks every 100ms
+        InvokeRepeating(nameof(SendMicData), 0.1f, 0.1f);
+    }
+
+    void SendMicData()
+    {
+        if (micClip == null || ws == null || ws.ReadyState != WebSocketState.Open)
+            return;
+
+        int pos = Microphone.GetPosition(null);
+        int diff = pos - lastSample;
+        if (diff <= 0)
+            return;
+
+        float[] samples = new float[diff * micClip.channels];
+        micClip.GetData(samples, lastSample);
+        byte[] bytes = FloatArrayToPCM16(samples);
+
+        ws.Send(bytes);
+        lastSample = pos;
+    }
+
+    byte[] FloatArrayToPCM16(float[] samples)
+    {
+        byte[] bytes = new byte[samples.Length * 2];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            short val = (short)(Mathf.Clamp(samples[i], -1f, 1f) * short.MaxValue);
+            byte[] byteArr = BitConverter.GetBytes(val);
+            bytes[i * 2] = byteArr[0];
+            bytes[i * 2 + 1] = byteArr[1];
+        }
+        return bytes;
+    }
+
+    void OnMessage(object sender, MessageEventArgs e)
+    {
+        if (!e.IsText)
+            return;
+
+        Payload payload = JsonUtility.FromJson<Payload>(e.Data);
+        if (!string.IsNullOrEmpty(payload.audio))
+        {
+            byte[] audioBytes = Convert.FromBase64String(payload.audio);
+            PlayAudio(audioBytes);
+        }
+    }
+
+    void PlayAudio(byte[] audioBytes)
+    {
+        int sampleCount = audioBytes.Length / 2;
+        float[] samples = new float[sampleCount];
+        for (int i = 0; i < sampleCount; i++)
+        {
+            short sample = BitConverter.ToInt16(audioBytes, i * 2);
+            samples[i] = sample / 32768f;
+        }
+
+        AudioClip clip = AudioClip.Create("assistant", sampleCount, 1, 24000, false);
+        clip.SetData(samples, 0);
+        audioSource.clip = clip;
+        audioSource.Play();
+    }
+
+    [Serializable]
+    public class Payload
+    {
+        public string audio;
+    }
+
+    void OnDestroy()
+    {
+        if (ws != null)
+            ws.Close();
+        Microphone.End(null);
+    }
+}

--- a/examples/unity_ws_server.py
+++ b/examples/unity_ws_server.py
@@ -1,0 +1,53 @@
+import os
+import asyncio
+from dotenv import load_dotenv
+from fastapi import FastAPI, WebSocket
+from fastapi.responses import JSONResponse
+
+from openai_realtime_client import RealtimeClient, TurnDetectionMode, WsHandler
+
+# Load environment variables from .env if present
+load_dotenv()
+
+app = FastAPI()
+
+
+@app.get("/health", response_class=JSONResponse)
+async def health_check():
+    """Simple health check endpoint."""
+    return {"message": "Unity Realtime server running"}
+
+
+@app.websocket("/ws")
+async def unity_realtime_endpoint(websocket: WebSocket):
+    """Handle audio streaming between Unity and the Realtime API."""
+    await websocket.accept()
+
+    ws_handler = WsHandler(websocket)
+    client = RealtimeClient(
+        api_key=os.getenv("OPENAI_API_KEY"),
+        model=os.getenv("OPENAI_MODEL"),
+        on_audio_delta=lambda audio: asyncio.create_task(ws_handler.send_audio(audio)),
+        on_text_delta=lambda text: print(f"\nAssistant: {text}", end="", flush=True),
+        on_input_transcript=lambda t: print(f"\nUser: {t}\nAssistant: ", end="", flush=True),
+        language="es",
+        turn_detection_mode=TurnDetectionMode.SEMANTIC_VAD,
+    )
+
+    await client.connect()
+    stream_task = asyncio.create_task(ws_handler.start_streaming(client))
+    handle_task = asyncio.create_task(client.handle_messages())
+
+    try:
+        await asyncio.gather(stream_task, handle_task)
+    except Exception as e:
+        print(f"Error: {e}")
+    finally:
+        await ws_handler.stop_streaming()
+        await client.close()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- add FastAPI WebSocket server for Unity NPCs
- provide Unity C# component to stream mic audio and play assistant speech
- document setup for server and Unity integration

## Testing
- `python -m py_compile examples/unity_ws_server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68947ef60b2083239ae0907fe2e91a7e