### PR TITLE
Make pynput optional and import only in local development

### DIFF
--- a/examples/manual_cli.py
+++ b/examples/manual_cli.py
@@ -2,7 +2,6 @@ import asyncio
 import os
 from dotenv import load_dotenv
 
-from pynput import keyboard
 from openai_realtime_client import RealtimeClient, InputHandler, AudioHandler
 from llama_index.core.tools import FunctionTool
 from tools import get_current_time
@@ -13,6 +12,12 @@ tools = [FunctionTool.from_defaults(fn=get_current_time)]
 
 async def main():
     load_dotenv()
+    try:
+        from pynput import keyboard  # type: ignore
+    except ImportError as e:
+        raise ImportError(
+            "pynput is required for this example. Install with the 'dev' extra."
+        ) from e
     # Initialize handlers
     audio_handler = AudioHandler()
     input_handler = InputHandler()
@@ -81,7 +86,8 @@ async def main():
 
 if __name__ == "__main__":
     # Install required packages:
-    # pip install pyaudio pynput pydub websockets
+    # pip install pyaudio pydub websockets
+    # Optional: pip install pynput
 
     print("Starting Realtime API CLI...")
     asyncio.run(main())

--- a/examples/streaming_cli.py
+++ b/examples/streaming_cli.py
@@ -2,8 +2,12 @@ import asyncio
 import os
 from dotenv import load_dotenv
 
-from pynput import keyboard
-from openai_realtime_client import RealtimeClient, AudioHandler, InputHandler, TurnDetectionMode
+from openai_realtime_client import (
+    RealtimeClient,
+    AudioHandler,
+    InputHandler,
+    TurnDetectionMode,
+)
 from llama_index.core.tools import FunctionTool
 from tools import get_current_time
 
@@ -15,6 +19,13 @@ load_dotenv()
 tools = [FunctionTool.from_defaults(fn=get_current_time)]
 
 async def main():
+    try:
+        from pynput import keyboard  # type: ignore
+    except ImportError as e:
+        raise ImportError(
+            "pynput is required for this example. Install with the 'dev' extra."
+        ) from e
+
     audio_handler = AudioHandler()
     input_handler = InputHandler()
     input_handler.loop = asyncio.get_running_loop()

--- a/examples/ws_hal9000.py
+++ b/examples/ws_hal9000.py
@@ -2,7 +2,6 @@ import os
 import asyncio
 from dotenv import load_dotenv
 from pydantic import BaseModel
-from pynput import keyboard
 from fastapi import FastAPI, WebSocket
 from fastapi.responses import JSONResponse
 from starlette.staticfiles import StaticFiles
@@ -60,6 +59,13 @@ async def handle_media_stream(websocket: WebSocket):
     ws_handler = WsHandler(websocket)
     input_handler = InputHandler()
     input_handler.loop = asyncio.get_running_loop()
+
+    try:
+        from pynput import keyboard  # type: ignore
+    except ImportError as e:
+        raise ImportError(
+            "pynput is required for this example. Install with the 'dev' extra."
+        ) from e
 
     client = RealtimeClient(
         api_key=os.getenv("OPENAI_API_KEY"),

--- a/openai_realtime_client/handlers/input_handler.py
+++ b/openai_realtime_client/handlers/input_handler.py
@@ -1,5 +1,4 @@
 import asyncio
-from pynput import keyboard
 
 
 class InputHandler:
@@ -15,6 +14,14 @@ class InputHandler:
         loop (asyncio.AbstractEventLoop): The event loop for the input handler.
     """
     def __init__(self):
+        try:
+            from pynput import keyboard  # type: ignore
+        except ImportError as e:
+            raise ImportError(
+                "pynput is required for InputHandler. Install with the 'dev' extra."
+            ) from e
+
+        self.keyboard = keyboard
         self.text_input = ""
         self.text_ready = asyncio.Event()
         self.command_queue = asyncio.Queue()
@@ -22,22 +29,22 @@ class InputHandler:
 
     def on_press(self, key):
         try:
-            if key == keyboard.Key.space:
+            if key == self.keyboard.Key.space:
                 self.loop.call_soon_threadsafe(
                     self.command_queue.put_nowait, ('space', None)
                 )
-            elif key == keyboard.Key.enter:
+            elif key == self.keyboard.Key.enter:
                 self.loop.call_soon_threadsafe(
                     self.command_queue.put_nowait, ('enter', self.text_input)
                 )
                 self.text_input = ""
-            elif key == keyboard.Key.backspace:
+            elif key == self.keyboard.Key.backspace:
                 self.text_input = self.text_input[:-1]
-            elif key == keyboard.KeyCode.from_char('r'):
+            elif key == self.keyboard.KeyCode.from_char('r'):
                 self.loop.call_soon_threadsafe(
                     self.command_queue.put_nowait, ('r', None)
                 )
-            elif key == keyboard.KeyCode.from_char('q'):
+            elif key == self.keyboard.KeyCode.from_char('q'):
                 self.loop.call_soon_threadsafe(
                     self.command_queue.put_nowait, ('q', None)
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ python = ">=3.13,<3.14"
 llama-index-core = "0.12.52.post1"
 pyaudio = "0.2.14"
 audioop-lts = { version = "0.2.1", python = ">=3.13" }
-pynput = "1.8.1"
+pynput = { version = "1.8.1", optional = true }
 pydub = "0.25.1"
 websockets = "15.0.1"
 wave = "0.0.2"
@@ -29,6 +29,9 @@ transformers = { version = "4.54.1", extras = ["torch"] }
 arize-phoenix="11.17.0"
 openinference-instrumentation-llama_index="4.3.3"
 llama-index-callbacks-openinference="0.3.0"
+
+[tool.poetry.extras]
+dev = ["pynput"]
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- make `pynput` an optional dependency with a `dev` extra
- load `pynput` lazily in `InputHandler` and examples

## Testing
- `poetry check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894dbf04d8483239593497bbc7855ad