### PR TITLE
Add docker-compose with Phoenix service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,8 @@ COPY . .
 RUN poetry config virtualenvs.create false \
  && poetry install --no-interaction --no-ansi --only main
 
+# ───────────── EXPONER PUERTO ─────────────
+EXPOSE 8000
+
 # ───────────── COMANDO POR DEFECTO ─────────────
 CMD ["python", "examples/unity_ws_server.py"]

--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ docker run --env-file .env -p 8000:8000 openai-realtime-demo
 
 This starts the FastAPI demo and exposes it on port `8000`.
 
+### Docker Compose
+
+The repository also includes a `docker-compose.yml` that spins up the app along
+with Phoenix monitoring and a Postgres database. To build the image and start
+everything:
+
+```bash
+docker compose up --build
+```
+
+The app will be available at `http://localhost:8000` and Phoenix at
+`http://localhost:6006`. The compose file mounts `rag_docs/` so you can edit
+documents on the host.
+
 
 **NOTE:** Streaming mode can be a little janky, best to use headphones in a quiet environment.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  phoenix:
+    image: arizephoenix/phoenix:latest
+    depends_on:
+      - db
+    ports:
+      - "6006:6006"
+      - "4317:4317"
+    environment:
+      PHOENIX_SQL_DATABASE_URL: postgresql://postgres:postgres@db:5432/postgres
+
+  db:
+    image: postgres:16
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    volumes:
+      - database_data:/var/lib/postgresql/data
+
+  app:
+    build: .
+    depends_on:
+      - phoenix
+    env_file:
+      - .env
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./rag_docs:/app/rag_docs
+
+volumes:
+  database_data:
+    driver: local

--- a/examples/unity/README.md
+++ b/examples/unity/README.md
@@ -13,6 +13,10 @@ pip install fastapi uvicorn websockets python-dotenv
 python examples/unity_ws_server.py
 ```
 
+   You can also run the server inside Docker using the instructions in the
+   project root README or start it alongside the monitoring stack with
+   `docker compose up`.
+
 The server exposes a WebSocket endpoint at `ws://localhost:8000/ws` that accepts raw PCM16 audio
 and returns base64 encoded audio chunks from the assistant.
 


### PR DESCRIPTION
## Summary
- Add docker-compose configuration with Phoenix monitoring, Postgres, and app services
- Document Docker Compose usage and expose app port 8000

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895b31e15c483239a524050178895be