### PR TITLE
feat: make qdrant hybrid search optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ OPENAI_MODEL=gpt-4o-mini-realtime-preview-2024-12-17
 TIMEZONE="Atlantic/Canary"
 RAG_DOCS_DIR=./rag_docs
 RAG_COLLECTION=rag_collection_name
+# Set to "true" to enable hybrid search (requires fastembed-gpu extra)
+RAG_ENABLE_HYBRID=false
 FASTEMBED_SPARSE_MODEL=Qdrant/bm25
 OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 OPENAI_EMBEDDING_SIZE=1536

--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,15 @@ OPENAI_MODEL=gpt-4o-mini-realtime-preview-2024-12-17
 TIMEZONE="Atlantic/Canary"
 RAG_DOCS_DIR=./rag_docs
 RAG_COLLECTION=rag_collection_name
-# Set to "true" to enable hybrid search (requires fastembed-gpu extra)
-RAG_ENABLE_HYBRID=false
+RAG_ENABLE_HYBRID=false # Set to "true" to enable hybrid search (requires fastembed-gpu extra)
 FASTEMBED_SPARSE_MODEL=Qdrant/bm25
 OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 OPENAI_EMBEDDING_SIZE=1536
 RAG_MODEL=o4-mini-2025-04-16
-PHOENIX_COLLECTOR_ENDPOINT = "http://localhost:6006"
+# Arize Phoenix Config
+PHOENIX_COLLECTOR_ENDPOINT=http://phoenix:6006
+PHOENIX_PROJECT_NAME=project_name
+OTEL_EXPORTER_OTLP_ENDPOINT=http://phoenix:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+OTEL_EXPORTER_OTLP_INSECURE=true
+# OTEL_TRACES_EXPORTER: otlp # limitar a trazas solamente:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ RUN poetry config virtualenvs.create false \
 EXPOSE 8000
 
 # ───────────── COMANDO POR DEFECTO ─────────────
-CMD ["python", "examples/unity_ws_server.py"]
+CMD ["python", "examples/ws_hal9000.py"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Place any text files you want indexed under `rag_docs/` in the project root.
 You can also specify another directory by setting the `RAG_DOCS_DIR`
 environment variable before running the examples.
 
+Hybrid search in Qdrant can be toggled with the `RAG_ENABLE_HYBRID` environment
+variable. Set it to `true` to enable dense + sparse retrieval and install the
+optional FastEmbed dependency:
+
+```bash
+poetry install -E fastembed-gpu
+```
+
+Set `RAG_ENABLE_HYBRID` to `false` to skip installing the extra dependency and
+perform pure semantic search. Valid values are `true` and `false`.
+
 ## Usage
 
 Assuming you installed and cloned the repo (or copy-pasted the examples), you can immediately run the examples.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,17 @@
 services:
   phoenix:
-    image: arizephoenix/phoenix:latest
+    image: arizephoenix/phoenix:11.22
     depends_on:
       - db
     ports:
-      - "6006:6006"
-      - "4317:4317"
+      - "6006:6006"   # UI de Phoenix
+      - "4317:4317"   # OTLP gRPC
+      # - "4318:4318" # OTLP HTTP (HTTP/protobuf)
+      # - "9090:9090" # [Optional] PROMETHEUS PORT IF ENABLED
     environment:
       PHOENIX_SQL_DATABASE_URL: postgresql://postgres:postgres@db:5432/postgres
+      PHOENIX_DEFAULT_RETENTION_POLICY_DAYS: 30
+      PHOENIX_ENABLE_PROMETHEUS: false
 
   db:
     image: postgres:16

--- a/examples/unity_ws_server.py
+++ b/examples/unity_ws_server.py
@@ -1,7 +1,7 @@
 import os
 import asyncio
 from dotenv import load_dotenv
-from fastapi import FastAPI, WebSocket
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 
 from openai_realtime_client import RealtimeClient, TurnDetectionMode, WsHandler
@@ -30,24 +30,44 @@ async def unity_realtime_endpoint(websocket: WebSocket):
         on_audio_delta=lambda audio: asyncio.create_task(ws_handler.send_audio(audio)),
         on_text_delta=lambda text: print(f"\nAssistant: {text}", end="", flush=True),
         on_input_transcript=lambda t: print(f"\nUser: {t}\nAssistant: ", end="", flush=True),
+        # Opcional: limpiar output si hay interrupciones/cortes
+        on_interrupt=lambda: asyncio.create_task(ws_handler.send_clear_event()),
         language="es",
         turn_detection_mode=TurnDetectionMode.SEMANTIC_VAD,
     )
 
-    await client.connect()
-    stream_task = asyncio.create_task(ws_handler.start_streaming(client))
-    handle_task = asyncio.create_task(client.handle_messages())
-
+    tasks = []
     try:
-        await asyncio.gather(stream_task, handle_task)
+        await client.connect()
+        print("Connected to OpenAI Realtime API!\n")
+
+        # Lanza tareas concurrentes
+        tasks.append(asyncio.create_task(client.handle_messages()))
+        tasks.append(asyncio.create_task(ws_handler.start_streaming(client)))
+
+        # Mantiene vivo el endpoint hasta que alguna falle o el cliente cierre
+        done, pending = await asyncio.wait(
+            tasks, return_when=asyncio.FIRST_EXCEPTION
+        )
+
+        # Propaga la primera excepción (si la hubo)
+        for d in done:
+            exc = d.exception()
+            if exc:
+                raise exc
+
+    except WebSocketDisconnect:
+        print("WebSocket client disconnected")
     except Exception as e:
         print(f"Error: {e}")
     finally:
+        for t in tasks:
+            t.cancel()
         await ws_handler.stop_streaming()
         await client.close()
 
 
 if __name__ == "__main__":
+    print("Starting Realtime Assistant server...")
     import uvicorn
-
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/openai_realtime_client/handlers/ws_handler.py
+++ b/openai_realtime_client/handlers/ws_handler.py
@@ -19,7 +19,7 @@ class WsHandler:
             return
 
         self.streaming = True
-        print("\nStreaming audio... Press 'q' to stop.")
+        print("\nStreaming audio...")
 
         while self.streaming:
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ llama-index-llms-openai = "0.4.7"
 llama-index-embeddings-openai = "0.3.1"
 llama-index-agent-openai="0.4.12"
 fastembed-gpu = { version = "0.7.1", optional = true }
-transformers = { version = "4.54.1", extras = ["torch"] }
+transformers = { version = "4.54.1", extras = ["torch"], optional = true }
 arize-phoenix="11.17.0"
 openinference-instrumentation-llama_index="4.3.3"
 llama-index-callbacks-openinference="0.3.0"
@@ -33,6 +33,7 @@ llama-index-callbacks-openinference="0.3.0"
 [tool.poetry.extras]
 dev = ["pynput"]
 fastembed-gpu = ["fastembed-gpu"]
+transformers = ["transformers"]
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ llama-index-vector-stores-qdrant = "0.6.1"
 llama-index-llms-openai = "0.4.7"
 llama-index-embeddings-openai = "0.3.1"
 llama-index-agent-openai="0.4.12"
-fastembed-gpu = "0.7.1"
+fastembed-gpu = { version = "0.7.1", optional = true }
 transformers = { version = "4.54.1", extras = ["torch"] }
 arize-phoenix="11.17.0"
 openinference-instrumentation-llama_index="4.3.3"
@@ -32,6 +32,7 @@ llama-index-callbacks-openinference="0.3.0"
 
 [tool.poetry.extras]
 dev = ["pynput"]
+fastembed-gpu = ["fastembed-gpu"]
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/rag/__init__.py
+++ b/rag/__init__.py
@@ -54,7 +54,7 @@ def get_index() -> VectorStoreIndex:
                                  required_exts=[".txt"],
                                  filename_as_id=True).load_data()
 
-    splitter = ParagraphSplitter(separator=r'\n{2,}')
+    splitter = ParagraphSplitter(separator=r'\n{1,}')
     nodes = splitter.get_nodes_from_documents(docs)
     print("Nodes: ", len(nodes))
 

--- a/rag/__init__.py
+++ b/rag/__init__.py
@@ -13,7 +13,12 @@ from llama_index.core import Settings
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.vector_stores.qdrant import QdrantVectorStore
 from qdrant_client import QdrantClient, AsyncQdrantClient
-from qdrant_client.models import Distance, VectorParams, SparseVectorParams, SparseIndexParams
+from qdrant_client.models import (
+    Distance,
+    VectorParams,
+    SparseVectorParams,
+    SparseIndexParams,
+)
 from openinference.instrumentation.llama_index import LlamaIndexInstrumentor
 from phoenix.otel import register
 
@@ -28,6 +33,10 @@ RAG_COLLECTION = os.getenv("RAG_COLLECTION")
 OPENAI_EMBEDDING_MODEL = os.getenv("OPENAI_EMBEDDING_MODEL")
 OPENAI_EMBEDDING_SIZE = int(os.getenv("OPENAI_EMBEDDING_SIZE"))
 FASTEMBED_SPARSE_MODEL = os.getenv("FASTEMBED_SPARSE_MODEL")
+# Toggle hybrid search (dense + sparse) in Qdrant. When disabled the sparse
+# fastembed model is not loaded and only dense semantic search is performed.
+# Enable Qdrant hybrid search when set to "true". Any other value disables it.
+RAG_ENABLE_HYBRID = os.getenv("RAG_ENABLE_HYBRID", "false").lower() == "true"
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 RAG_DOCS_DIR = os.path.join(BASE_DIR, os.getenv("RAG_DOCS_DIR"))
 
@@ -55,26 +64,34 @@ def get_index() -> VectorStoreIndex:
     #aclient = AsyncQdrantClient(path=":memory:")
 
     if not client.collection_exists(RAG_COLLECTION):
-        client.create_collection(
-            collection_name=RAG_COLLECTION,
-            vectors_config={
+        create_collection_kwargs = {
+            "collection_name": RAG_COLLECTION,
+            "vectors_config": {
                 "text-dense": VectorParams(
                     size=OPENAI_EMBEDDING_SIZE,
                     distance=Distance.COSINE,
                 )
             },
-            sparse_vectors_config={
-                "text-sparse": SparseVectorParams(
-                    index=SparseIndexParams()
-                )
-            },
-        )
+        }
+        if RAG_ENABLE_HYBRID:
+            create_collection_kwargs["sparse_vectors_config"] = {
+                "text-sparse": SparseVectorParams(index=SparseIndexParams())
+            }
+        client.create_collection(**create_collection_kwargs)
 
-    vector_store = QdrantVectorStore(client=client,
-                                     #aclient=aclient, no es posible con qdrant en memoria!
-                                     collection_name=RAG_COLLECTION,
-                                     enable_hybrid=True,
-                                     fastembed_sparse_model=FASTEMBED_SPARSE_MODEL)
+    vector_store_kwargs = {
+        "client": client,
+        #"aclient": aclient, # no es posible con qdrant en memoria!
+        "collection_name": RAG_COLLECTION,
+    }
+    if RAG_ENABLE_HYBRID:
+        vector_store_kwargs.update(
+            {
+                "enable_hybrid": True,
+                "fastembed_sparse_model": FASTEMBED_SPARSE_MODEL,
+            }
+        )
+    vector_store = QdrantVectorStore(**vector_store_kwargs)
     storage = StorageContext.from_defaults(vector_store=vector_store)
     embed_model = OpenAIEmbedding(model=OPENAI_EMBEDDING_MODEL,
                                   dimensions=OPENAI_EMBEDDING_SIZE)


### PR DESCRIPTION
## Summary
- move fastembed-gpu to optional Poetry extra installed only when `RAG_ENABLE_HYBRID` is `true`
- restrict `RAG_ENABLE_HYBRID` to `true` or `false` and document how to install the extra dependency
- add guidance about enabling hybrid search in `.env.example`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895c14771308323a5fa9c0f8b19f9b9