### PR TITLE
feat: add WebRTC support to realtime client

### DIFF
--- a/examples/hal9000_webrtc.py
+++ b/examples/hal9000_webrtc.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from starlette.staticfiles import StaticFiles
 from prometheus_fastapi_instrumentator import Instrumentator
-from openai_realtime_client import RealtimeClient, TurnDetectionMode, RtcHandler
+from openai_realtime_client import RealtimeClient, TurnDetectionMode, RtcHandler, ConnectionMode
 from llama_index.core.tools import FunctionTool, ToolMetadata
 from tools import get_current_time, get_current_date, query_rag
 
@@ -71,6 +71,7 @@ async def handle_media_stream(offer: Offer):
         turn_detection_mode=TurnDetectionMode.SEMANTIC_VAD,
         language="es",
         tools=tools,
+        connection_mode=ConnectionMode.WEBRTC,
     )
 
     await client.connect()

--- a/examples/unity_webrtc_server.py
+++ b/examples/unity_webrtc_server.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from openai_realtime_client import RealtimeClient, TurnDetectionMode, RtcHandler
+from openai_realtime_client import RealtimeClient, TurnDetectionMode, RtcHandler, ConnectionMode
 
 load_dotenv()
 
@@ -35,6 +35,7 @@ async def unity_webrtc_endpoint(offer: Offer):
         on_interrupt=lambda: asyncio.create_task(rtc_handler.send_clear_event()),
         language="es",
         turn_detection_mode=TurnDetectionMode.SEMANTIC_VAD,
+        connection_mode=ConnectionMode.WEBRTC,
     )
 
     await client.connect()

--- a/openai_realtime_client/__init__.py
+++ b/openai_realtime_client/__init__.py
@@ -1,4 +1,4 @@
-from .client.realtime_client import RealtimeClient, TurnDetectionMode
+from .client.realtime_client import RealtimeClient, TurnDetectionMode, ConnectionMode
 from .handlers.audio_handler import AudioHandler
 from .handlers.input_handler import InputHandler
 from .handlers.ws_handler import WsHandler
@@ -7,6 +7,7 @@ from .handlers.rtc_handler import RtcHandler
 __all__ = [
     "RealtimeClient",
     "TurnDetectionMode",
+    "ConnectionMode",
     "AudioHandler",
     "InputHandler",
     "WsHandler",

--- a/openai_realtime_client/client/realtime_client.py
+++ b/openai_realtime_client/client/realtime_client.py
@@ -9,6 +9,13 @@ import logging
 from typing import Optional, Callable, List, Dict, Any
 from enum import Enum
 from pydub import AudioSegment
+from aiortc import (
+    RTCPeerConnection,
+    RTCSessionDescription,
+    MediaStreamTrack,
+)
+from av.audio.frame import AudioFrame
+import aiohttp
 
 from llama_index.core.tools import BaseTool, AsyncBaseTool, ToolSelection, adapt_to_async_tool, call_tool_with_selection
 
@@ -26,6 +33,31 @@ class TurnDetectionMode(Enum):
     SERVER_VAD = "server_vad"
     SEMANTIC_VAD = "semantic_vad"
     MANUAL = "manual"
+
+
+class ConnectionMode(Enum):
+    WEBSOCKET = "websocket"
+    WEBRTC = "webrtc"
+
+
+class OutgoingAudioStreamTrack(MediaStreamTrack):
+    """Audio track that pulls audio chunks from a queue."""
+
+    kind = "audio"
+
+    def __init__(self):
+        super().__init__()
+        self._queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+    async def recv(self) -> AudioFrame:
+        audio = await self._queue.get()
+        frame = AudioFrame(format="s16", layout="mono", samples=len(audio) // 2)
+        frame.planes[0].update(audio)
+        frame.sample_rate = 24000
+        return frame
+
+    async def send_audio(self, audio: bytes) -> None:
+        await self._queue.put(audio)
 
 class RealtimeClient:
     """
@@ -78,6 +110,7 @@ class RealtimeClient:
         temperature: float = 0.8,
         language: str = "en",
         turn_detection_mode: TurnDetectionMode = TurnDetectionMode.MANUAL,
+        connection_mode: ConnectionMode = ConnectionMode.WEBSOCKET,
         tools: Optional[List[BaseTool]] = None,
         on_text_delta: Optional[Callable[[str], None]] = None,
         on_audio_delta: Optional[Callable[[bytes], None]] = None,
@@ -98,7 +131,12 @@ class RealtimeClient:
         self.instructions = instructions
         self.temperature = temperature
         self.language = language
-        self.base_url = "wss://api.openai.com/v1/realtime"
+        self.connection_mode = connection_mode
+        self.base_url = (
+            "wss://api.openai.com/v1/realtime"
+            if connection_mode == ConnectionMode.WEBSOCKET
+            else "https://api.openai.com/v1/realtime"
+        )
         self.extra_event_handlers = extra_event_handlers or {}
         self.turn_detection_mode = turn_detection_mode
 
@@ -114,10 +152,21 @@ class RealtimeClient:
         # Track printing state for input and output transcripts
         self._print_input_transcript = False
         self._output_transcript_buffer = ""
-        
-        
 
-        
+        # WebRTC specific attributes
+        self.pc: Optional[RTCPeerConnection] = None
+        self.data_channel = None
+        self.outgoing: Optional[OutgoingAudioStreamTrack] = None
+        self._message_queue: Optional[asyncio.Queue[str]] = None
+        self._dc_ready: Optional[asyncio.Event] = None
+
+    async def _send_event(self, event: Dict[str, Any]) -> None:
+        data = json.dumps(event)
+        if self.connection_mode == ConnectionMode.WEBSOCKET:
+            await self.ws.send(data)
+        else:
+            if self.data_channel and self.data_channel.readyState == "open":
+                self.data_channel.send(data)
 
     async def connect(self) -> None:
         """Establish WebSocket connection with the Realtime API.
@@ -125,23 +174,66 @@ class RealtimeClient:
         Raises:
             RuntimeError: If the WebSocket connection fails.
         """
-        url = f"{self.base_url}?model={self.model}"
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "OpenAI-Beta": "realtime=v1"
-        }
+        if self.connection_mode == ConnectionMode.WEBSOCKET:
+            url = f"{self.base_url}?model={self.model}"
+            headers = {
+                "Authorization": f"Bearer {self.api_key}",
+                "OpenAI-Beta": "realtime=v1"
+            }
 
-        try:
-            self.ws = await websockets.connect(url, additional_headers=headers)
-        except (OSError, websockets.WebSocketException) as e:
-            logger.exception("Failed to connect to the Realtime API")
-            raise RuntimeError("Failed to establish connection to the Realtime API") from e
-        
+            try:
+                self.ws = await websockets.connect(url, additional_headers=headers)
+            except (OSError, websockets.WebSocketException) as e:
+                logger.exception("Failed to connect to the Realtime API")
+                raise RuntimeError("Failed to establish connection to the Realtime API") from e
+        else:
+            self.pc = RTCPeerConnection()
+            self.outgoing = OutgoingAudioStreamTrack()
+            self.pc.addTrack(self.outgoing)
+            self.data_channel = self.pc.createDataChannel("oai-events")
+            self._message_queue = asyncio.Queue()
+            self._dc_ready = asyncio.Event()
+
+            @self.data_channel.on("open")
+            def on_open():
+                if self._dc_ready:
+                    self._dc_ready.set()
+
+            @self.data_channel.on("message")
+            def on_message(message):
+                if self._message_queue:
+                    asyncio.create_task(self._message_queue.put(message))
+
+            @self.pc.on("track")
+            def on_track(track):
+                if track.kind == "audio":
+                    asyncio.create_task(self._handle_remote_audio(track))
+
+            offer = await self.pc.createOffer()
+            await self.pc.setLocalDescription(offer)
+
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{self.base_url}?model={self.model}",
+                    data=offer.sdp,
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "Content-Type": "application/sdp",
+                    },
+                ) as resp:
+                    answer_sdp = await resp.text()
+
+            await self.pc.setRemoteDescription(
+                RTCSessionDescription(sdp=answer_sdp, type="answer")
+            )
+
+            if self._dc_ready:
+                await self._dc_ready.wait()
+
         # Set up default session configuration
         tools = [t.metadata.to_openai_tool()['function'] for t in self.tools]
         for t in tools:
             t['type'] = 'function'  # TODO: OpenAI docs didn't say this was needed, but it was
-
 
         if self.turn_detection_mode == TurnDetectionMode.MANUAL:
             await self.update_session({
@@ -220,7 +312,7 @@ class RealtimeClient:
             "type": "session.update",
             "session": config
         }
-        await self.ws.send(json.dumps(event))
+        await self._send_event(event)
 
     async def send_text(self, text: str) -> None:
         """Send text message to the API."""
@@ -235,40 +327,44 @@ class RealtimeClient:
                 }]
             }
         }
-        await self.ws.send(json.dumps(event))
+        await self._send_event(event)
         await self.create_response()
 
     async def send_audio(self, audio_bytes: bytes) -> None:
         """Send audio data to the API."""
         # Convert audio to required format (24kHz, mono, PCM16)
-        pcm_data = await asyncio.to_thread(_convert_audio_bytes, audio_bytes)
-        
-        # Append audio to buffer
-        append_event = {
-            "type": "input_audio_buffer.append",
-            "audio": pcm_data
-        }
-        await self.ws.send(json.dumps(append_event))
-        
-        # Commit the buffer
-        commit_event = {
-            "type": "input_audio_buffer.commit"
-        }
-        await self.ws.send(json.dumps(commit_event))
-        
-        # In manual mode, we need to explicitly request a response
+        pcm_b64 = await asyncio.to_thread(_convert_audio_bytes, audio_bytes)
+
+        if self.connection_mode == ConnectionMode.WEBSOCKET:
+            append_event = {
+                "type": "input_audio_buffer.append",
+                "audio": pcm_b64
+            }
+            await self._send_event(append_event)
+
+            commit_event = {
+                "type": "input_audio_buffer.commit"
+            }
+            await self._send_event(commit_event)
+        else:
+            if self.outgoing:
+                await self.outgoing.send_audio(base64.b64decode(pcm_b64))
+
         if self.turn_detection_mode == TurnDetectionMode.MANUAL:
             await self.create_response()
 
     async def stream_audio(self, audio_chunk: bytes) -> None:
         """Stream raw audio data to the API."""
-        audio_b64 = base64.b64encode(audio_chunk).decode()
-        
-        append_event = {
-            "type": "input_audio_buffer.append",
-            "audio": audio_b64
-        }
-        await self.ws.send(json.dumps(append_event))
+        if self.connection_mode == ConnectionMode.WEBSOCKET:
+            audio_b64 = base64.b64encode(audio_chunk).decode()
+            append_event = {
+                "type": "input_audio_buffer.append",
+                "audio": audio_b64
+            }
+            await self._send_event(append_event)
+        else:
+            if self.outgoing:
+                await self.outgoing.send_audio(audio_chunk)
 
     async def create_response(self, functions: Optional[List[Dict[str, Any]]] = None) -> None:
         """Request a response from the API. Needed when using manual mode."""
@@ -280,8 +376,7 @@ class RealtimeClient:
         }
         if functions:
             event["response"]["tools"] = functions # type: ignore
-            
-        await self.ws.send(json.dumps(event))
+        await self._send_event(event)
 
     async def send_function_result(self, call_id: str, result: Any) -> None:
         """Send function call result back to the API."""
@@ -293,7 +388,7 @@ class RealtimeClient:
                 "output": result
             }
         }
-        await self.ws.send(json.dumps(event))
+        await self._send_event(event)
 
         # functions need a manual response
         await self.create_response()
@@ -303,7 +398,7 @@ class RealtimeClient:
         event = {
             "type": "response.cancel"
         }
-        await self.ws.send(json.dumps(event))
+        await self._send_event(event)
     
     async def truncate_response(self):
         """Truncate the conversation item to match what was actually played."""
@@ -312,7 +407,7 @@ class RealtimeClient:
                 "type": "conversation.item.truncate",
                 "item_id": self._current_item_id
             }
-            await self.ws.send(json.dumps(event))
+            await self._send_event(event)
 
     async def call_tool(self, call_id: str,tool_name: str, tool_arguments: Dict[str, Any]) -> None:
         tool_selection = ToolSelection(
@@ -350,88 +445,110 @@ class RealtimeClient:
         self._current_response_id = None
         self._current_item_id = None
 
+    async def _process_event(self, message: str) -> None:
+        event = json.loads(message)
+        event_type = event.get("type")
+
+        if event_type == "error":
+            print(f"Error: {event['error']}")
+            return
+
+        # Track response state
+        if event_type == "response.created":
+            self._current_response_id = event.get("response", {}).get("id")
+            self._is_responding = True
+
+        elif event_type == "response.output_item.added":
+            self._current_item_id = event.get("item", {}).get("id")
+
+        elif event_type == "response.done":
+            self._is_responding = False
+            self._current_response_id = None
+            self._current_item_id = None
+
+        # Handle interruptions
+        elif event_type == "input_audio_buffer.speech_started":
+            print("\n[Speech detected]")
+            if self._is_responding:
+                await self.handle_interruption()
+
+            if self.on_interrupt:
+                self.on_interrupt()
+
+        elif event_type == "input_audio_buffer.speech_stopped":
+            print("\n[Speech ended]")
+
+        # Handle normal response events
+        elif event_type == "response.text.delta":
+            if self.on_text_delta:
+                self.on_text_delta(event["delta"])
+
+        elif event_type == "response.audio.delta":
+            if self.on_audio_delta:
+                audio_bytes = base64.b64decode(event["delta"])
+                self.on_audio_delta(audio_bytes)
+
+        elif event_type == "response.function_call_arguments.done":
+            await self.call_tool(event["call_id"], event['name'], json.loads(event['arguments']))
+
+        # Handle input audio transcription
+        elif event_type == "conversation.item.input_audio_transcription.completed":
+            transcript = event.get("transcript", "")
+
+            if self.on_input_transcript:
+                await asyncio.to_thread(self.on_input_transcript, transcript)
+                self._print_input_transcript = True
+
+        # Handle output audio transcription
+        elif event_type == "response.audio_transcript.delta":
+            if self.on_output_transcript:
+                delta = event.get("delta", "")
+                if not self._print_input_transcript:
+                    self._output_transcript_buffer += delta
+                else:
+                    if self._output_transcript_buffer:
+                        await asyncio.to_thread(
+                            self.on_output_transcript, self._output_transcript_buffer
+                        )
+                        self._output_transcript_buffer = ""
+                    await asyncio.to_thread(self.on_output_transcript, delta)
+
+        elif event_type == "response.audio_transcript.done":
+            self._print_input_transcript = False
+
+        elif event_type in self.extra_event_handlers:
+            self.extra_event_handlers[event_type](event)
+
     async def handle_messages(self) -> None:
         try:
-            async for message in self.ws:
-                event = json.loads(message)
-                event_type = event.get("type")
-                
-                if event_type == "error":
-                    print(f"Error: {event['error']}")
-                    continue
-                
-                # Track response state
-                elif event_type == "response.created":
-                    self._current_response_id = event.get("response", {}).get("id")
-                    self._is_responding = True
-                
-                elif event_type == "response.output_item.added":
-                    self._current_item_id = event.get("item", {}).get("id")
-                
-                elif event_type == "response.done":
-                    self._is_responding = False
-                    self._current_response_id = None
-                    self._current_item_id = None
-                
-                # Handle interruptions
-                elif event_type == "input_audio_buffer.speech_started":
-                    print("\n[Speech detected]")
-                    if self._is_responding:
-                        await self.handle_interruption()
-
-                    if self.on_interrupt:
-                        self.on_interrupt()
-
-                
-                elif event_type == "input_audio_buffer.speech_stopped":
-                    print("\n[Speech ended]")
-                
-                # Handle normal response events
-                elif event_type == "response.text.delta":
-                    if self.on_text_delta:
-                        self.on_text_delta(event["delta"])
-                        
-                elif event_type == "response.audio.delta":
-                    if self.on_audio_delta:
-                        audio_bytes = base64.b64decode(event["delta"])
-                        self.on_audio_delta(audio_bytes)
-                        
-                elif event_type == "response.function_call_arguments.done":
-                    await self.call_tool(event["call_id"], event['name'], json.loads(event['arguments']))
-
-                # Handle input audio transcription
-                elif event_type == "conversation.item.input_audio_transcription.completed":
-                    transcript = event.get("transcript", "")
-                    
-                    if self.on_input_transcript:
-                        await asyncio.to_thread(self.on_input_transcript,transcript)
-                        self._print_input_transcript = True
-
-                # Handle output audio transcription
-                elif event_type == "response.audio_transcript.delta":
-                    if self.on_output_transcript:
-                        delta = event.get("delta", "")
-                        if not self._print_input_transcript:
-                            self._output_transcript_buffer += delta
-                        else:
-                            if self._output_transcript_buffer:
-                                await asyncio.to_thread(self.on_output_transcript,self._output_transcript_buffer)
-                                self._output_transcript_buffer = ""
-                            await asyncio.to_thread(self.on_output_transcript,delta)
-
-
-                elif event_type == "response.audio_transcript.done":
-                    self._print_input_transcript = False
-
-                elif event_type in self.extra_event_handlers:
-                    self.extra_event_handlers[event_type](event)
-
+            if self.connection_mode == ConnectionMode.WEBSOCKET:
+                async for message in self.ws:
+                    await self._process_event(message)
+            else:
+                while True:
+                    if self._message_queue is None:
+                        break
+                    message = await self._message_queue.get()
+                    await self._process_event(message)
         except websockets.exceptions.ConnectionClosed:
             print("Connection closed")
         except Exception as e:
             print(f"Error in message handling: {str(e)}")
 
+    async def _handle_remote_audio(self, track: MediaStreamTrack) -> None:
+        while True:
+            try:
+                frame = await track.recv()
+                if self.on_audio_delta:
+                    self.on_audio_delta(frame.planes[0].to_bytes())
+            except Exception:
+                break
+
     async def close(self) -> None:
-        """Close the WebSocket connection."""
-        if self.ws:
-            await self.ws.close()
+        """Close the active connection."""
+        if self.connection_mode == ConnectionMode.WEBSOCKET:
+            if self.ws:
+                await self.ws.close()
+        else:
+            if self.pc:
+                await self.pc.close()


### PR DESCRIPTION
## Summary
- extend RealtimeClient with ConnectionMode for WebSocket or WebRTC operation
- expose ConnectionMode from package and update WebRTC examples to use it

## Testing
- `python -m py_compile openai_realtime_client/client/realtime_client.py examples/hal9000_webrtc.py examples/unity_webrtc_server.py openai_realtime_client/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a30163a8a08323aafd4e9f3133e878