### PR TITLE
feat: add webrtc transport option

### DIFF
--- a/examples/hal9000_webrtc.py
+++ b/examples/hal9000_webrtc.py
@@ -6,7 +6,12 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from starlette.staticfiles import StaticFiles
 from prometheus_fastapi_instrumentator import Instrumentator
-from openai_realtime_client import RealtimeClient, TurnDetectionMode, RtcHandler
+from openai_realtime_client import (
+    RealtimeClient,
+    TurnDetectionMode,
+    RtcHandler,
+    ConnectionMode,
+)
 from llama_index.core.tools import FunctionTool, ToolMetadata
 from tools import get_current_time, get_current_date, query_rag
 
@@ -60,6 +65,8 @@ class Offer(BaseModel):
 async def handle_media_stream(offer: Offer):
     rtc_handler = RtcHandler()
 
+    transport = ConnectionMode.WEBRTC if os.getenv("OPENAI_TRANSPORT", "webrtc").lower() == "webrtc" else ConnectionMode.WEBSOCKET
+
     client = RealtimeClient(
         api_key=os.getenv("OPENAI_API_KEY"),
         model=os.getenv("OPENAI_MODEL"),
@@ -71,6 +78,7 @@ async def handle_media_stream(offer: Offer):
         turn_detection_mode=TurnDetectionMode.SEMANTIC_VAD,
         language="es",
         tools=tools,
+        connection_mode=transport,
     )
 
     await client.connect()

--- a/examples/unity_webrtc_server.py
+++ b/examples/unity_webrtc_server.py
@@ -5,7 +5,12 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from openai_realtime_client import RealtimeClient, TurnDetectionMode, RtcHandler
+from openai_realtime_client import (
+    RealtimeClient,
+    TurnDetectionMode,
+    RtcHandler,
+    ConnectionMode,
+)
 
 load_dotenv()
 
@@ -26,6 +31,9 @@ async def health_check():
 async def unity_webrtc_endpoint(offer: Offer):
     """Handle WebRTC offer from Unity and stream audio with the Realtime API."""
     rtc_handler = RtcHandler()
+
+    transport = ConnectionMode.WEBRTC if os.getenv("OPENAI_TRANSPORT", "webrtc").lower() == "webrtc" else ConnectionMode.WEBSOCKET
+
     client = RealtimeClient(
         api_key=os.getenv("OPENAI_API_KEY"),
         model=os.getenv("OPENAI_MODEL"),
@@ -35,6 +43,7 @@ async def unity_webrtc_endpoint(offer: Offer):
         on_interrupt=lambda: asyncio.create_task(rtc_handler.send_clear_event()),
         language="es",
         turn_detection_mode=TurnDetectionMode.SEMANTIC_VAD,
+        connection_mode=transport,
     )
 
     await client.connect()

--- a/examples/unity_webrtc_server.py
+++ b/examples/unity_webrtc_server.py
@@ -27,9 +27,9 @@ async def health_check():
     return {"message": "Unity Realtime WebRTC server running"}
 
 
-@app.post("/offer")
+@app.post("/webrtc")
 async def unity_webrtc_endpoint(offer: Offer):
-    """Handle WebRTC offer from Unity and stream audio with the Realtime API."""
+    """Handle WebRTC offer from a client and stream audio with the Realtime API."""
     rtc_handler = RtcHandler()
 
     transport = ConnectionMode.WEBRTC if os.getenv("OPENAI_TRANSPORT", "webrtc").lower() == "webrtc" else ConnectionMode.WEBSOCKET

--- a/openai_realtime_client/__init__.py
+++ b/openai_realtime_client/__init__.py
@@ -1,4 +1,4 @@
-from .client.realtime_client import RealtimeClient, TurnDetectionMode
+from .client.realtime_client import RealtimeClient, TurnDetectionMode, ConnectionMode
 from .handlers.audio_handler import AudioHandler
 from .handlers.input_handler import InputHandler
 from .handlers.ws_handler import WsHandler
@@ -7,6 +7,7 @@ from .handlers.rtc_handler import RtcHandler
 __all__ = [
     "RealtimeClient",
     "TurnDetectionMode",
+    "ConnectionMode",
     "AudioHandler",
     "InputHandler",
     "WsHandler",

--- a/openai_realtime_client/client/realtime_client.py
+++ b/openai_realtime_client/client/realtime_client.py
@@ -214,6 +214,7 @@ class RealtimeClient:
             headers = {
                 "Authorization": f"Bearer {self.api_key}",
                 "Content-Type": "application/sdp",
+                "OpenAI-Beta": "realtime=v1",
             }
             async with aiohttp.ClientSession() as session:
                 async with session.post(http_url, data=offer.sdp, headers=headers) as r:

--- a/openai_realtime_client/client/realtime_client.py
+++ b/openai_realtime_client/client/realtime_client.py
@@ -10,7 +10,17 @@ from typing import Optional, Callable, List, Dict, Any
 from enum import Enum
 from pydub import AudioSegment
 
-from llama_index.core.tools import BaseTool, AsyncBaseTool, ToolSelection, adapt_to_async_tool, call_tool_with_selection
+from aiortc import RTCPeerConnection, RTCSessionDescription, MediaStreamTrack
+from av.audio.frame import AudioFrame
+import aiohttp
+
+from llama_index.core.tools import (
+    BaseTool,
+    AsyncBaseTool,
+    ToolSelection,
+    adapt_to_async_tool,
+    call_tool_with_selection,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +36,33 @@ class TurnDetectionMode(Enum):
     SERVER_VAD = "server_vad"
     SEMANTIC_VAD = "semantic_vad"
     MANUAL = "manual"
+
+
+class ConnectionMode(Enum):
+    """Supported transport mechanisms for the Realtime API."""
+
+    WEBSOCKET = "websocket"
+    WEBRTC = "webrtc"
+
+
+class _OutgoingAudioStreamTrack(MediaStreamTrack):
+    """Audio track used to send PCM16 audio over WebRTC."""
+
+    kind = "audio"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+    async def recv(self) -> AudioFrame:
+        audio = await self._queue.get()
+        frame = AudioFrame(format="s16", layout="mono", samples=len(audio) // 2)
+        frame.planes[0].update(audio)
+        frame.sample_rate = 24000
+        return frame
+
+    async def send_audio(self, audio: bytes) -> None:
+        await self._queue.put(audio)
 
 class RealtimeClient:
     """
@@ -68,7 +105,7 @@ class RealtimeClient:
             Is a mapping of event names to functions that process the event payload.
     """
     def __init__(
-        self, 
+        self,
         api_key: str,
         model: str = os.environ.get(
             "OPENAI_MODEL", "gpt-4o-mini-realtime-preview-2024-12-17"
@@ -78,11 +115,12 @@ class RealtimeClient:
         temperature: float = 0.8,
         language: str = "en",
         turn_detection_mode: TurnDetectionMode = TurnDetectionMode.MANUAL,
+        connection_mode: ConnectionMode = ConnectionMode.WEBSOCKET,
         tools: Optional[List[BaseTool]] = None,
         on_text_delta: Optional[Callable[[str], None]] = None,
         on_audio_delta: Optional[Callable[[bytes], None]] = None,
         on_interrupt: Optional[Callable[[], None]] = None,
-        on_input_transcript: Optional[Callable[[str], None]] = None,  
+        on_input_transcript: Optional[Callable[[str], None]] = None,
         on_output_transcript: Optional[Callable[[str], None]] = None,  
         extra_event_handlers: Optional[Dict[str, Callable[[Dict[str, Any]], None]]] = None
     ):
@@ -90,6 +128,12 @@ class RealtimeClient:
         self.model = model
         self.voice = voice
         self.ws = None
+        self.pc: Optional[RTCPeerConnection] = None
+        self.dc = None
+        self._event_queue: Optional[asyncio.Queue] = None
+        self._data_channel_ready: Optional[asyncio.Event] = None
+        self._outgoing_track: Optional[_OutgoingAudioStreamTrack] = None
+        self.connection_mode = connection_mode
         self.on_text_delta = on_text_delta
         self.on_audio_delta = on_audio_delta
         self.on_interrupt = on_interrupt
@@ -120,107 +164,157 @@ class RealtimeClient:
         
 
     async def connect(self) -> None:
-        """Establish WebSocket connection with the Realtime API.
-
-        Raises:
-            RuntimeError: If the WebSocket connection fails.
-        """
+        """Establish connection with the Realtime API."""
         url = f"{self.base_url}?model={self.model}"
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "OpenAI-Beta": "realtime=v1"
-        }
 
-        try:
-            self.ws = await websockets.connect(url, additional_headers=headers)
-        except (OSError, websockets.WebSocketException) as e:
-            logger.exception("Failed to connect to the Realtime API")
-            raise RuntimeError("Failed to establish connection to the Realtime API") from e
-        
+        if self.connection_mode == ConnectionMode.WEBSOCKET:
+            headers = {
+                "Authorization": f"Bearer {self.api_key}",
+                "OpenAI-Beta": "realtime=v1",
+            }
+
+            try:
+                self.ws = await websockets.connect(url, additional_headers=headers)
+            except (OSError, websockets.WebSocketException) as e:
+                logger.exception("Failed to connect to the Realtime API")
+                raise RuntimeError(
+                    "Failed to establish connection to the Realtime API"
+                ) from e
+        else:
+            self.pc = RTCPeerConnection()
+            self._event_queue = asyncio.Queue()
+            self._data_channel_ready = asyncio.Event()
+            self.dc = self.pc.createDataChannel("oai-events")
+
+            @self.dc.on("open")
+            def _on_open():
+                self._data_channel_ready.set()
+
+            @self.dc.on("message")
+            def _on_message(message: str):
+                try:
+                    payload = json.loads(message)
+                except Exception:
+                    return
+                self._event_queue.put_nowait(payload)
+
+            self._outgoing_track = _OutgoingAudioStreamTrack()
+            self.pc.addTrack(self._outgoing_track)
+
+            if self.on_audio_delta:
+                @self.pc.on("track")
+                def _on_track(track):
+                    if track.kind == "audio":
+                        asyncio.create_task(self._relay_remote_audio(track))
+
+            offer = await self.pc.createOffer()
+            await self.pc.setLocalDescription(offer)
+
+            http_url = url.replace("wss://", "https://")
+            headers = {
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/sdp",
+            }
+            async with aiohttp.ClientSession() as session:
+                async with session.post(http_url, data=offer.sdp, headers=headers) as r:
+                    answer_sdp = await r.text()
+
+            await self.pc.setRemoteDescription(
+                RTCSessionDescription(sdp=answer_sdp, type="answer")
+            )
+
+            await self._data_channel_ready.wait()
+
         # Set up default session configuration
-        tools = [t.metadata.to_openai_tool()['function'] for t in self.tools]
+        tools = [t.metadata.to_openai_tool()["function"] for t in self.tools]
         for t in tools:
-            t['type'] = 'function'  # TODO: OpenAI docs didn't say this was needed, but it was
-
+            t["type"] = "function"  # TODO: required for OpenAI
 
         if self.turn_detection_mode == TurnDetectionMode.MANUAL:
-            await self.update_session({
-                "modalities": ["text", "audio"],
-                "instructions": self.instructions,
-                "voice": self.voice,
-                "input_audio_format": "pcm16",
-                "input_audio_noise_reduction": {
-                    "type": "far_field"
-                },
-                "output_audio_format": "pcm16",
-                "input_audio_transcription": {
-                    "model": "gpt-4o-mini-transcribe",
-                    "language": self.language,
-                },
-                "tools": tools,
-                "tool_choice": "auto",
-                "temperature": self.temperature,
-            })
+            await self.update_session(
+                {
+                    "modalities": ["text", "audio"],
+                    "instructions": self.instructions,
+                    "voice": self.voice,
+                    "input_audio_format": "pcm16",
+                    "input_audio_noise_reduction": {"type": "far_field"},
+                    "output_audio_format": "pcm16",
+                    "input_audio_transcription": {
+                        "model": "gpt-4o-mini-transcribe",
+                        "language": self.language,
+                    },
+                    "tools": tools,
+                    "tool_choice": "auto",
+                    "temperature": self.temperature,
+                }
+            )
         elif self.turn_detection_mode == TurnDetectionMode.SERVER_VAD:
-            await self.update_session({
-                "modalities": ["text", "audio"],
-                "instructions": self.instructions,
-                "voice": self.voice,
-                "input_audio_format": "pcm16",
-                "input_audio_noise_reduction": {
-                    "type": "far_field"
-                },
-                "output_audio_format": "pcm16",
-                "input_audio_transcription": {
-                    "model": "gpt-4o-mini-transcribe",
-                    "language": self.language,
-                },
-                "turn_detection": {
-                    "type": "server_vad",
-                    "threshold": 0.5,
-                    "prefix_padding_ms": 500,
-                    "silence_duration_ms": 200,
-                    "create_response": True,
-                    "interrupt_response": True,
-                },
-                "tools": tools,
-                "tool_choice": "auto",
-                "temperature": self.temperature,
-            })
+            await self.update_session(
+                {
+                    "modalities": ["text", "audio"],
+                    "instructions": self.instructions,
+                    "voice": self.voice,
+                    "input_audio_format": "pcm16",
+                    "input_audio_noise_reduction": {"type": "far_field"},
+                    "output_audio_format": "pcm16",
+                    "input_audio_transcription": {
+                        "model": "gpt-4o-mini-transcribe",
+                        "language": self.language,
+                    },
+                    "turn_detection": {
+                        "type": "server_vad",
+                        "threshold": 0.5,
+                        "prefix_padding_ms": 500,
+                        "silence_duration_ms": 200,
+                        "create_response": True,
+                        "interrupt_response": True,
+                    },
+                    "tools": tools,
+                    "tool_choice": "auto",
+                    "temperature": self.temperature,
+                }
+            )
         elif self.turn_detection_mode == TurnDetectionMode.SEMANTIC_VAD:
-            await self.update_session({
-                "modalities": ["text", "audio"],
-                "instructions": self.instructions,
-                "voice": self.voice,
-                "input_audio_format": "pcm16",
-                "input_audio_noise_reduction": {
-                    "type": "far_field"
-                },
-                "output_audio_format": "pcm16",
-                "input_audio_transcription": {
-                    "model": "gpt-4o-mini-transcribe",
-                    "language": self.language,
-                },
-                "turn_detection": {
-                    "type": "semantic_vad",
-                    "eagerness": "auto",
-                    "create_response": True,
-                    "interrupt_response": True,
-                },
-                "tools": tools,
-                "tool_choice": "auto",
-                "temperature": self.temperature,
-            })
+            await self.update_session(
+                {
+                    "modalities": ["text", "audio"],
+                    "instructions": self.instructions,
+                    "voice": self.voice,
+                    "input_audio_format": "pcm16",
+                    "input_audio_noise_reduction": {"type": "far_field"},
+                    "output_audio_format": "pcm16",
+                    "input_audio_transcription": {
+                        "model": "gpt-4o-mini-transcribe",
+                        "language": self.language,
+                    },
+                    "turn_detection": {
+                        "type": "semantic_vad",
+                        "eagerness": "auto",
+                        "create_response": True,
+                        "interrupt_response": True,
+                    },
+                    "tools": tools,
+                    "tool_choice": "auto",
+                    "temperature": self.temperature,
+                }
+            )
         else:
             raise ValueError(f"Invalid turn detection mode: {self.turn_detection_mode}")
 
+    async def _send_event(self, event: Dict[str, Any]) -> None:
+        """Send an event using the active transport."""
+        if self.connection_mode == ConnectionMode.WEBSOCKET:
+            if self.ws:
+                await self.ws.send(json.dumps(event))
+        else:
+            if self.dc:
+                await self._data_channel_ready.wait()
+                self.dc.send(json.dumps(event))
+
     async def update_session(self, config: Dict[str, Any]) -> None:
         """Update session configuration."""
-        event = {
-            "type": "session.update",
-            "session": config
-        }
-        await self.ws.send(json.dumps(event))
+        event = {"type": "session.update", "session": config}
+        await self._send_event(event)
 
     async def send_text(self, text: str) -> None:
         """Send text message to the API."""
@@ -235,7 +329,7 @@ class RealtimeClient:
                 }]
             }
         }
-        await self.ws.send(json.dumps(event))
+        await self._send_event(event)
         await self.create_response()
 
     async def send_audio(self, audio_bytes: bytes) -> None:
@@ -248,13 +342,13 @@ class RealtimeClient:
             "type": "input_audio_buffer.append",
             "audio": pcm_data
         }
-        await self.ws.send(json.dumps(append_event))
+        await self._send_event(append_event)
         
         # Commit the buffer
         commit_event = {
             "type": "input_audio_buffer.commit"
         }
-        await self.ws.send(json.dumps(commit_event))
+        await self._send_event(commit_event)
         
         # In manual mode, we need to explicitly request a response
         if self.turn_detection_mode == TurnDetectionMode.MANUAL:
@@ -262,13 +356,13 @@ class RealtimeClient:
 
     async def stream_audio(self, audio_chunk: bytes) -> None:
         """Stream raw audio data to the API."""
-        audio_b64 = base64.b64encode(audio_chunk).decode()
-        
-        append_event = {
-            "type": "input_audio_buffer.append",
-            "audio": audio_b64
-        }
-        await self.ws.send(json.dumps(append_event))
+        if self.connection_mode == ConnectionMode.WEBSOCKET:
+            audio_b64 = base64.b64encode(audio_chunk).decode()
+            append_event = {"type": "input_audio_buffer.append", "audio": audio_b64}
+            await self._send_event(append_event)
+        else:
+            if self._outgoing_track:
+                await self._outgoing_track.send_audio(audio_chunk)
 
     async def create_response(self, functions: Optional[List[Dict[str, Any]]] = None) -> None:
         """Request a response from the API. Needed when using manual mode."""
@@ -280,8 +374,7 @@ class RealtimeClient:
         }
         if functions:
             event["response"]["tools"] = functions # type: ignore
-            
-        await self.ws.send(json.dumps(event))
+        await self._send_event(event)
 
     async def send_function_result(self, call_id: str, result: Any) -> None:
         """Send function call result back to the API."""
@@ -293,7 +386,7 @@ class RealtimeClient:
                 "output": result
             }
         }
-        await self.ws.send(json.dumps(event))
+        await self._send_event(event)
 
         # functions need a manual response
         await self.create_response()
@@ -303,7 +396,7 @@ class RealtimeClient:
         event = {
             "type": "response.cancel"
         }
-        await self.ws.send(json.dumps(event))
+        await self._send_event(event)
     
     async def truncate_response(self):
         """Truncate the conversation item to match what was actually played."""
@@ -312,7 +405,7 @@ class RealtimeClient:
                 "type": "conversation.item.truncate",
                 "item_id": self._current_item_id
             }
-            await self.ws.send(json.dumps(event))
+            await self._send_event(event)
 
     async def call_tool(self, call_id: str,tool_name: str, tool_arguments: Dict[str, Any]) -> None:
         tool_selection = ToolSelection(
@@ -350,88 +443,110 @@ class RealtimeClient:
         self._current_response_id = None
         self._current_item_id = None
 
+    async def _handle_event(self, event: Dict[str, Any]) -> None:
+        event_type = event.get("type")
+
+        if event_type == "error":
+            print(f"Error: {event['error']}")
+            return
+
+        # Track response state
+        if event_type == "response.created":
+            self._current_response_id = event.get("response", {}).get("id")
+            self._is_responding = True
+
+        elif event_type == "response.output_item.added":
+            self._current_item_id = event.get("item", {}).get("id")
+
+        elif event_type == "response.done":
+            self._is_responding = False
+            self._current_response_id = None
+            self._current_item_id = None
+
+        # Handle interruptions
+        elif event_type == "input_audio_buffer.speech_started":
+            print("\n[Speech detected]")
+            if self._is_responding:
+                await self.handle_interruption()
+
+            if self.on_interrupt:
+                self.on_interrupt()
+
+        elif event_type == "input_audio_buffer.speech_stopped":
+            print("\n[Speech ended]")
+
+        # Handle normal response events
+        elif event_type == "response.text.delta":
+            if self.on_text_delta:
+                self.on_text_delta(event["delta"])
+
+        elif event_type == "response.audio.delta":
+            if self.on_audio_delta:
+                audio_bytes = base64.b64decode(event["delta"])
+                self.on_audio_delta(audio_bytes)
+
+        elif event_type == "response.function_call_arguments.done":
+            await self.call_tool(
+                event["call_id"], event["name"], json.loads(event["arguments"])
+            )
+
+        # Handle input audio transcription
+        elif event_type == "conversation.item.input_audio_transcription.completed":
+            transcript = event.get("transcript", "")
+
+            if self.on_input_transcript:
+                await asyncio.to_thread(self.on_input_transcript, transcript)
+                self._print_input_transcript = True
+
+        # Handle output audio transcription
+        elif event_type == "response.audio_transcript.delta":
+            if self.on_output_transcript:
+                delta = event.get("delta", "")
+                if not self._print_input_transcript:
+                    self._output_transcript_buffer += delta
+                else:
+                    if self._output_transcript_buffer:
+                        await asyncio.to_thread(
+                            self.on_output_transcript, self._output_transcript_buffer
+                        )
+                        self._output_transcript_buffer = ""
+                    await asyncio.to_thread(self.on_output_transcript, delta)
+
+        elif event_type == "response.audio_transcript.done":
+            self._print_input_transcript = False
+
+        elif event_type in self.extra_event_handlers:
+            self.extra_event_handlers[event_type](event)
+
     async def handle_messages(self) -> None:
         try:
-            async for message in self.ws:
-                event = json.loads(message)
-                event_type = event.get("type")
-                
-                if event_type == "error":
-                    print(f"Error: {event['error']}")
-                    continue
-                
-                # Track response state
-                elif event_type == "response.created":
-                    self._current_response_id = event.get("response", {}).get("id")
-                    self._is_responding = True
-                
-                elif event_type == "response.output_item.added":
-                    self._current_item_id = event.get("item", {}).get("id")
-                
-                elif event_type == "response.done":
-                    self._is_responding = False
-                    self._current_response_id = None
-                    self._current_item_id = None
-                
-                # Handle interruptions
-                elif event_type == "input_audio_buffer.speech_started":
-                    print("\n[Speech detected]")
-                    if self._is_responding:
-                        await self.handle_interruption()
-
-                    if self.on_interrupt:
-                        self.on_interrupt()
-
-                
-                elif event_type == "input_audio_buffer.speech_stopped":
-                    print("\n[Speech ended]")
-                
-                # Handle normal response events
-                elif event_type == "response.text.delta":
-                    if self.on_text_delta:
-                        self.on_text_delta(event["delta"])
-                        
-                elif event_type == "response.audio.delta":
-                    if self.on_audio_delta:
-                        audio_bytes = base64.b64decode(event["delta"])
-                        self.on_audio_delta(audio_bytes)
-                        
-                elif event_type == "response.function_call_arguments.done":
-                    await self.call_tool(event["call_id"], event['name'], json.loads(event['arguments']))
-
-                # Handle input audio transcription
-                elif event_type == "conversation.item.input_audio_transcription.completed":
-                    transcript = event.get("transcript", "")
-                    
-                    if self.on_input_transcript:
-                        await asyncio.to_thread(self.on_input_transcript,transcript)
-                        self._print_input_transcript = True
-
-                # Handle output audio transcription
-                elif event_type == "response.audio_transcript.delta":
-                    if self.on_output_transcript:
-                        delta = event.get("delta", "")
-                        if not self._print_input_transcript:
-                            self._output_transcript_buffer += delta
-                        else:
-                            if self._output_transcript_buffer:
-                                await asyncio.to_thread(self.on_output_transcript,self._output_transcript_buffer)
-                                self._output_transcript_buffer = ""
-                            await asyncio.to_thread(self.on_output_transcript,delta)
-
-
-                elif event_type == "response.audio_transcript.done":
-                    self._print_input_transcript = False
-
-                elif event_type in self.extra_event_handlers:
-                    self.extra_event_handlers[event_type](event)
-
+            if self.connection_mode == ConnectionMode.WEBSOCKET:
+                async for message in self.ws:
+                    event = json.loads(message)
+                    await self._handle_event(event)
+            else:
+                while True:
+                    event = await self._event_queue.get()
+                    await self._handle_event(event)
         except websockets.exceptions.ConnectionClosed:
             print("Connection closed")
         except Exception as e:
             print(f"Error in message handling: {str(e)}")
 
+    async def _relay_remote_audio(self, track: MediaStreamTrack) -> None:
+        while True:
+            try:
+                frame = await track.recv()
+                if self.on_audio_delta:
+                    self.on_audio_delta(frame.planes[0].to_bytes())
+            except Exception:
+                break
+
     async def close(self) -> None:
-        """Close the WebSocket connection."""
-        if self.ws:
-            await self.ws.close()
+        """Close the connection."""
+        if self.connection_mode == ConnectionMode.WEBSOCKET:
+            if self.ws:
+                await self.ws.close()
+        else:
+            if self.pc:
+                await self.pc.close()


### PR DESCRIPTION
## Summary
- extend `RealtimeClient` with `ConnectionMode` enum and WebRTC transport support
- allow examples to select WebSocket or WebRTC connection via `OPENAI_TRANSPORT`

## Testing
- `python -m py_compile examples/hal9000_webrtc.py examples/unity_webrtc_server.py openai_realtime_client/__init__.py openai_realtime_client/client/realtime_client.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a321d499848323a1e149a59c979e32